### PR TITLE
Force to replace the old package

### DIFF
--- a/src/PlatformBase.js
+++ b/src/PlatformBase.js
@@ -176,7 +176,7 @@ function(packagePath) {
         throw new InvalidPathException("Package could not be found " + this.pkgPath);
     }
 
-    ShellJS.mv(packagePath, this.pkgPath);
+    ShellJS.mv('-f', packagePath, this.pkgPath);
 };
 
 /**


### PR DESCRIPTION
After a backend has built a target package, it should export the package
into 'pkg' directory, if there already exists one package in it, the
'PlatformBase' should replace it with the new one.

BUG=#30