### PR TITLE
Hide 'CROSSWALK_APP_TOOLS_CACHE_DIR' for iOS help

### DIFF
--- a/src/Main.js
+++ b/src/Main.js
@@ -279,8 +279,10 @@ function(parser) {
         }
     }
 
-    output.write("Environment Variables\n\n");
-    output.write("    CROSSWALK_APP_TOOLS_CACHE_DIR\t\tKeep downloaded files in this dir\n");
+    if (platformInfo.platformId != 'ios') {
+        output.write("Environment Variables\n\n");
+        output.write("    CROSSWALK_APP_TOOLS_CACHE_DIR\t\tKeep downloaded files in this dir\n");
+    }
     output.write("\n");
 };
 


### PR DESCRIPTION
As iOS backend don't need to download crosswalk prebuild packages,
the CROSSWALK_APP_TOOLS_CACHE_DIR is useless for now and need to
be hide.

https://crosswalk-project.org/jira/browse/XWALK-4152