### PR TITLE
Make license identifier SPDX compliant

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.7.0",
   "description": "An APK packager for the Crosswalk Project -- http://crosswalk-project.org",
   "author": "Robert Staudinger <robert.staudinger@intel.com>",
-  "license": "Apache V2",
+  "license": "Apache-2.0",
   "engines" : {
     "node" : ">=0.12"
   },


### PR DESCRIPTION
Removes the warning "npm WARN package.json crosswalk-app-tools@0.7.0 license should be a valid SPDX license expression" on npm install