### PR TITLE
Manifest: Throw error on invalid xwalk_app_version

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -55,7 +55,7 @@ function Manifest(output, path) {
 
     if (!this._appVersion) {
         output.error("Invalid app version '" + json.xwalk_app_version + "' in the manifest");
-        // TODO maybe exception
+        throw new Error("Invalid app version '" + json.xwalk_app_version + "' in the manifest");
     }
 
     // Name


### PR DESCRIPTION
When field xwalk_app_version is invalid, do not attempt to continue
but just throw an error. There is no way to recover anyway.

BUG=XWALK-5255