### PR TITLE
Android: Allow passing package-id to crosswalk-pkg

### DIFF
--- a/src/CommandParser.js
+++ b/src/CommandParser.js
@@ -38,6 +38,9 @@ function() {
 "    crosswalk-app check [<platforms>]           Check host setup\n" +
 "                                                Check all platforms if none given\n" +
 "\n" +
+"    crosswalk-app manifest <path>               Initialize web manifest in <path>\n" +
+"                  --package-id=<package-id>     Canonical package name e.g. com.example.foo\n" +
+"\n" +
 "    crosswalk-app create <package-id>           Create project <package-id>\n" +
 "                  --platforms=<target>          Optional, e.g. \"windows\"\n" +
 "\n" +
@@ -66,8 +69,6 @@ function() {
 
     var cmd = this.peekCommand();
     switch (cmd) {
-    case "check":
-        return cmd;
     case "create":
         var packageId = this.createGetPackageId();
         return packageId !== null ? cmd : null;
@@ -81,6 +82,8 @@ function() {
     case "build":
         var type = this.buildGetType();
         return type !== null ? cmd : null;
+    case "check":
+    case "manifest":
     case "platforms":
     case "help":
     case "version":
@@ -113,7 +116,7 @@ function() {
         return "help";
     }
 
-    if (["check", "create", "update", "refresh", "build", "platforms"].indexOf(command) > -1) {
+    if (["check", "manifest", "create", "update", "refresh", "build", "platforms"].indexOf(command) > -1) {
         return command;
     }
 
@@ -132,6 +135,19 @@ function() {
     // So we take everything from the third index
     var platforms = this._argv.slice(3);
     return platforms;
+};
+
+/**
+ * Get path where to initialize manifest.
+ * @returns {String} Path
+ */
+CommandParser.prototype.manifestGetPath =
+function() {
+
+    // Command goes like this
+    // node crosswalk-app manifest <path> ...
+    // So we take the 3rd element.
+    return this._argv[3];
 };
 
 /**

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -364,6 +364,9 @@ function(output, path, packageId) {
         }
     }
 
+    // Always overwrite xwalk_package_id
+    json.xwalk_package_id = packageId;
+
     // Write back
     buffer = FormatJson.plain(json);
     FS.writeFileSync(path, buffer);

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -49,27 +49,33 @@ if (ShellJS.test("-d", appPath)) {
 
 // Determine packageId
 var packageId = null;
-var manifestPath = Path.join(appPath, "manifest.json");
-var buffer = null;
-if (ShellJS.test("-f", manifestPath)) {
-    buffer = FS.readFileSync(manifestPath, {"encoding": "utf8"});
+if (argv.m || argv.manifest) {
+    // packageId from command-line?
+    packageId = CommandParser.validatePackageId(argv.m ? argv.m : argv.manifest, output);
+} else {
+    // packageId from existing web manifest?
+    var manifestPath = Path.join(appPath, "manifest.json");
+    var buffer = null;
+    if (ShellJS.test("-f", manifestPath)) {
+        buffer = FS.readFileSync(manifestPath, {"encoding": "utf8"});
+    }
+    if (!buffer) {
+        output.error("Failed to read manifest.json in " + appPath);
+        output.info("Please create a minimal manifest.json by pasting the following content");
+        output.info('{ "xwalk_package_id": "com.example.foo" }');
+        process.exit(cat.EXIT_CODE_ERROR);
+    }
+    var json = JSON.parse(buffer);
+    if (!json) {
+        output.error("Failed to parse manifest.json");
+        process.exit(cat.EXIT_CODE_ERROR);
+    }
+    if (!json.xwalk_package_id) {
+        output.error("Missing field 'xwalk_package_id' in the form of 'com.example.foo' in manifest.json");
+        process.exit(cat.EXIT_CODE_ERROR);
+    }
+    packageId = CommandParser.validatePackageId(json.xwalk_package_id, output);
 }
-if (!buffer) {
-    output.error("Failed to read manifest.json in " + appPath);
-    output.info("Please create a minimal manifest.json by pasting the following content");
-    output.info('{ "xwalk_package_id": "com.example.foo" }');
-    process.exit(cat.EXIT_CODE_ERROR);
-}
-var json = JSON.parse(buffer);
-if (!json) {
-    output.error("Failed to parse manifest.json");
-    process.exit(cat.EXIT_CODE_ERROR);
-}
-if (!json.xwalk_package_id) {
-    output.error("Missing field 'xwalk_package_id' in the form of 'com.example.foo' in manifest.json");
-    process.exit(cat.EXIT_CODE_ERROR);
-}
-var packageId = CommandParser.validatePackageId(json.xwalk_package_id, output);
 if (!packageId) {
     process.exit(cat.EXIT_CODE_ERROR);
 }
@@ -84,12 +90,18 @@ function help() {
         "  <options>\n" +
         "    -c --crosswalk=<version-spec>: Runtime version\n" +
         "    -h --help: Print usage information\n" +
+        "    -m --manifest=<package-id>: Fill manifest.json with crosswalk defaults\n" +
         "    -p --platforms=<android|windows>: Target platform\n" +
         "    -r --release=true: Build release packages\n" +
         "    -v --version: Print tool version\n" +
         "\n" +
         "  <path>\n" +
         "    Path to directory that contains a web app\n" +
+        "\n" +
+        "  <package-id>\n" +
+        "    Canonical application name, e.g. com.example.foo, needs to\n" +
+        "    * Comprise of 3 or more period-separated parts\n" +
+        "    * Begin with lowecase letters\n" +
         "\n" +
         "  <version-spec>\n" +
         "    * Channel name, i.e. stable/beta/canary\n" +
@@ -109,6 +121,18 @@ function check(app, extraArgs, output, callback) {
 
     output.highlight("Checking host setup");
     app.check(extraArgs.platforms, output, callback);
+}
+
+// Initialize app tools
+function manifest(app, fill, appPath, packageId, output, callback) {
+
+    if (fill) {
+        output.highlight("Filling manifest.json in " + appPath);
+        app.initManifest(appPath, {"package-id": packageId}, output, callback);
+        return;
+    }
+
+    callback(cat.EXIT_CODE_OK);
 }
 
 // Initialize app tools
@@ -200,6 +224,8 @@ if (argv.platforms) {
     extraArgs.platforms = [ argv.platforms ];
 }
 
+var fill = argv.m || argv.manifest;
+
 var buildConfig = null;
 if (argv.r || argv.release) {
     buildConfig = "release";
@@ -207,12 +233,13 @@ if (argv.r || argv.release) {
 
 // Build steps
 var tasks = [
-    { func: check,  args: [ cat, extraArgs, output      ] },
-    { func: init,   args: [ cat, packageId              ] },
-    { func: create, args: [ cat, packageId, extraArgs   ] },
-    { func: copy,   args: [ cat, appPath, extraArgs     ] },
-    { func: build,  args: [ cat, buildConfig, extraArgs ] },
-    { func: clean,  args: [ cat                         ] }
+    { func: check,    args: [ cat, extraArgs, output                ] },
+    { func: manifest, args: [ cat, fill, appPath, packageId, output ] },
+    { func: init,     args: [ cat, packageId                        ] },
+    { func: create,   args: [ cat, packageId, extraArgs             ] },
+    { func: copy,     args: [ cat, appPath, extraArgs               ] },
+    { func: build,    args: [ cat, buildConfig, extraArgs           ] },
+    { func: clean,    args: [ cat                                   ] }
 ];
 
 util.iterate(


### PR DESCRIPTION
By passing -m / --manifest=<package-id> to crosswalk-pkg, one can
forgo needing a minimal manifest.json, it will created and filled
with the package-id and other default values.

backport-candidate

BUG=XWALK-5167
BUG=XWALK-5257