### PR TITLE
Improve warning message when manifest fields are invalid

### DIFF
--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -86,7 +86,7 @@ function Manifest(output, path) {
             // supported mode
             this._display = json.display;
         } else {
-            output.warning("Unsupported value '" + json.display + "' in manifest.json");
+            output.warning("Unsupported value '" + json.display + "' for 'display' in manifest.json");
         }
     }
 
@@ -107,7 +107,7 @@ function Manifest(output, path) {
             // supported mode
             this._orientation = json.orientation;
         } else {
-            output.warning("Unsupported value '" + json.orientation + "' in manifest.json");
+            output.warning("Unsupported value '" + json.orientation + "' for 'orientation' in manifest.json");
         }
     }
 


### PR DESCRIPTION
Print the name of the manifest member when an unsupported value is specified.

Note: while testing this I noticed that the warnings are printed twice, but it doesn't seem related to this PR.

BUG=XWALK-5262