### PR TITLE
crosswalk-pkg: Add args -a --android for platform-specific config

### DIFF
--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -24,6 +24,8 @@ var util = require("./util/index.js");
 
 // Parse args
 var argv = Minimist(process.argv.slice(2));
+
+// Help
 if (!process.argv[2] ||
     argv.h ||
     argv.help) {
@@ -88,15 +90,20 @@ function help() {
         "  Usage: crosswalk-pkg <options> <path>\n" +
         "\n" +
         "  <options>\n" +
-        "    -c --crosswalk=<version-spec>: Runtime version\n" +
-        "    -h --help: Print usage information\n" +
-        "    -m --manifest=<package-id>: Fill manifest.json with crosswalk defaults\n" +
-        "    -p --platforms=<android|windows>: Target platform\n" +
-        "    -r --release=true: Build release packages\n" +
-        "    -v --version: Print tool version\n" +
+        '    -a --android="<android-confs>"   Extra configurations for Android\n' +
+        "    -c --crosswalk=<version-spec>    Runtime version\n" +
+        "    -h --help                        Print usage information\n" +
+        "    -m --manifest=<package-id>       Fill manifest.json with default values\n" +
+        "    -p --platforms=<android|windows> Target platform\n" +
+        "    -r --release=true                Build release packages\n" +
+        "    -v --version                     Print tool version\n" +
         "\n" +
         "  <path>\n" +
         "    Path to directory that contains a web app\n" +
+        "\n" +
+        "  <android-confs>\n" +
+        "    Quoted string of values, e.g. \"shared\"\n" +
+        "    * \"shared\": Build APK that depends on crosswalk in the Google Play Store\n" +
         "\n" +
         "  <package-id>\n" +
         "    Canonical application name, e.g. com.example.foo, needs to\n" +
@@ -159,6 +166,12 @@ function init(app, packageId, callback) {
 // Create skeleton
 function create(app, packageId, extraArgs, callback) {
 
+    var androidArgs = extraArgs.android.split(" ");
+
+    if (androidArgs.indexOf("shared") > -1) {
+        extraArgs["android-shared"] = true;
+    }
+
     app.create(packageId, extraArgs, callback);
 }
 
@@ -206,6 +219,7 @@ function clean(app, callback) {
 // Arguments
 var extraArgs = {};
 
+// Crosswalk, see help for <version-spec>
 if (argv.c) {
     // TODO implement way to pass through parameters w/o platform prefix
     extraArgs["android-crosswalk"] = argv.c;
@@ -230,6 +244,9 @@ if (argv.m) {
 if (argv.manifest) {
     extraArgs.manifest = argv.manifest;
 }
+
+// Extra android config
+extraArgs.android = argv.android;
 
 var buildConfig = null;
 if (argv.r || argv.release) {


### PR DESCRIPTION
E.g. passing --android="shared" builds a package depending on the
shared crosswalk APK in Google Play Store.

BUG=XWALK-5259