### PR TITLE
Android: Improve downloader for empty channels

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -41,6 +41,7 @@ function AndroidPlatform(PlatformBase, baseData) {
 
     instance._sdk = new AndroidSDK(instance.application);
     instance._channel = "stable";
+    instance._lite = false;
     instance._shared = false;
     instance._apiTarget = null;
 
@@ -65,6 +66,7 @@ function() {
                          "\t\t\t\t\t\tor version number (w.x.y.z)\n" +
                          "\t\t\t\t\t\tor crosswalk zip\n" +
                          "\t\t\t\t\t\tor xwalk_app_template dir",
+            "lite": "                      Use crosswalk-lite, see Crosswalk Wiki for details",
             "shared": "                    Depend on shared crosswalk installation"
         }
     };
@@ -401,6 +403,15 @@ function(packageId, args, callback) {
     var util = this.application.util;
     var output = this.application.output;
 
+    if (args.lite && args.shared) {
+        callback("Options \"lite\" and \"shared\" can not be used together");
+        return;
+    }
+
+    if (args.lite) {
+        this._lite = true;
+    }
+
     if (args.shared) {
         this._shared = true;
     }
@@ -446,6 +457,9 @@ function(packageId, args, callback) {
             }
 
             var deps = new util.Download01Org(this.application, "android", "stable" /* FIXME this is just a placeholder */);
+            if (this._lite) {
+                deps.androidFlavor = "crosswalk-lite";
+            }
             deps.importCrosswalk(versionSpec,
                                  function(path) {
                                      return this.importCrosswalkFromDisk(path);

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -90,7 +90,7 @@ function help() {
         "  Usage: crosswalk-pkg <options> <path>\n" +
         "\n" +
         "  <options>\n" +
-        '    -a --android="<android-confs>"   Extra configurations for Android\n' +
+        '    -a --android="<android-conf>"    Extra configurations for Android\n' +
         "    -c --crosswalk=<version-spec>    Runtime version\n" +
         "    -h --help                        Print usage information\n" +
         "    -m --manifest=<package-id>       Fill manifest.json with default values\n" +
@@ -101,9 +101,10 @@ function help() {
         "  <path>\n" +
         "    Path to directory that contains a web app\n" +
         "\n" +
-        "  <android-confs>\n" +
-        "    Quoted string of values, e.g. \"shared\"\n" +
-        "    * \"shared\": Build APK that depends on crosswalk in the Google Play Store\n" +
+        "  <android-conf>\n" +
+        "    Quoted string with extra config, e.g. \"shared\"\n" +
+        "    * \"shared\" Build APK that depends on crosswalk in the Google Play Store\n" +
+        "    * \"lite\"   Use crosswalk-lite, see Crosswalk Wiki\n" +
         "\n" +
         "  <package-id>\n" +
         "    Canonical application name, e.g. com.example.foo, needs to\n" +
@@ -166,8 +167,15 @@ function init(app, packageId, callback) {
 // Create skeleton
 function create(app, packageId, extraArgs, callback) {
 
-    var androidArgs = extraArgs.android.split(" ");
+    var androidArgs = [];
+    if (extraArgs.android) {
+        androidArgs = extraArgs.android.split(" ");
+    }
 
+    // TODO implement way to pass through parameters w/o platform prefix
+    if (androidArgs.indexOf("lite") > -1) {
+        extraArgs["android-lite"] = true;
+    }
     if (androidArgs.indexOf("shared") > -1) {
         extraArgs["android-shared"] = true;
     }

--- a/src/util/Downloader.js
+++ b/src/util/Downloader.js
@@ -122,6 +122,10 @@ function(urlInfo, callback) {
     getFunc(urlInfo, function(res) {
 
         if (res.statusCode != 200) {
+            this._stream.end();
+            this._stream = null;
+            this._url = null;
+            res.req.abort();
             callback("Download failed: HTTP Status " + res.statusCode);
             return;
         }

--- a/test/download-01-org.js
+++ b/test/download-01-org.js
@@ -87,6 +87,23 @@ exports.tests = {
         });
     },
 
+    lite: function(test) {
+
+        test.expect(1);
+
+        var application = Util.createTmpApplication("com.example.foo");
+        var deps = new Download01Org(application, "android", "stable");
+        deps.androidFlavor = "crosswalk-lite";
+        deps.findCrosswalkVersion(null, null,
+                                  function(version, channel, errormsg) {
+
+            test.equal(typeof version, "string");
+
+            Util.deleteTmpApplication(application);
+            test.done();
+        });
+    },
+
     invalid: function(test) {
 
         test.expect(2);


### PR DESCRIPTION
App-tools would hang in the end when iterating through empty
channels, like stable/beta for windows and lite. Fix this by
aborting the index page download on an error response (e.g. 404).

BUG=XWALK-5568