### PR TITLE
Make sure to pack OpenGL dll files with the application.

### DIFF
--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -174,6 +174,9 @@ function(app_path, xwalk_path, meta_data, callback) {
     AddFileComponent(app_root_folder, xwalk_path, 'icudtl.dat');
     AddFileComponent(app_root_folder, xwalk_path, 'natives_blob.bin');
     AddFileComponent(app_root_folder, xwalk_path, 'snapshot_blob.bin');
+    AddFileComponent(app_root_folder, xwalk_path, 'libEGL.dll');
+    AddFileComponent(app_root_folder, xwalk_path, 'libGLESv2.dll');
+    AddFileComponent(app_root_folder, xwalk_path, 'osmesa.dll');
 
     var subfolder_map = {};
 


### PR DESCRIPTION
Starting with build 17.45.426.0 we're shipping few extra DLLs
which are needed for WebGL support. This patch make sure we
pack them in the final .msi.

BUG=XWALK-5506, XWALK-4982