### PR TITLE
Commands: Remove "clean", "update" and "refresh" commands

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -491,51 +491,6 @@ function(packageId, args, callback) {
 };
 
 /**
- * Implements {@link PlatformBase.update}
- */
-AndroidPlatform.prototype.update =
-function(versionSpec, args, callback) {
-
-    // Namespace util
-    var util = this.application.util;
-    var output = this.application.output;
-
-    var sdk = new AndroidSDK(this.application);
-    sdk.queryTarget(AndroidPlatform.MIN_API_LEVEL,
-                    function(apiTarget, errormsg) {
-
-        if (errormsg) {
-            callback(errormsg);
-            return;
-        }
-        this._apiTarget = apiTarget;
-
-        var deps = new util.Download01Org(this.application, "android", "stable" /* FIXME this is just a placeholder */);
-        deps.importCrosswalk(versionSpec,
-                             function(path) {
-                                 return this.importCrosswalkFromDisk(path);
-                             }.bind(this),
-                             function(version, errormsg) {
-
-            if (errormsg) {
-                output.error(errormsg);
-                callback("Updating crosswalk to '" + version + "' failed");
-                return;
-            }
-
-            output.info("Project updated to crosswalk '" + version + "'");
-            callback(null);
-        });
-    }.bind(this));
-};
-
-AndroidPlatform.prototype.refresh =
-function() {
-
-    // TODO implement
-};
-
-/**
  * Enable ABIs so they are built into the APK.
  * @param {String} [abi] ABI identifier "armeabi-v7a" / "x86". When not passed,
  *                       all ABIs are enabled

--- a/android/lib/AndroidSDK.js
+++ b/android/lib/AndroidSDK.js
@@ -188,12 +188,6 @@ function(path, packageId, apiTarget, callback) {
     }.bind(this));
 };
 
-AndroidSDK.prototype.refreshProject =
-function() {
-
-    // TODO
-};
-
 /**
  * Build project by running "ant debug" or "ant release".
  * @param {Boolean} release Whether to build a release or debug package

--- a/examples/crosswalk-app-tools-backend-demo/lib/DemoPlatform.js
+++ b/examples/crosswalk-app-tools-backend-demo/lib/DemoPlatform.js
@@ -36,9 +36,6 @@ DemoPlatform.getArgs = function() {
         create: { // Extra options for command "create"
             foo: "Option added by the backend",
             bar: "Another option added by the backend"
-        },
-        update: { // Extra options for command "update"
-            baz: "Another option added by the backend"
         }
     };
 };
@@ -51,31 +48,6 @@ function(packageId, args, callback) {
 
     // TODO implement generation of project.
     this.output.write("DemoPlatform: Generating " + this.packageId + "\n");
-
-    // Null means success, error string means failure.
-    callback(null);
-};
-
-/**
- * Implements {@link PlatformBase.update}
- */
-DemoPlatform.prototype.update =
-function(versionSpec, args, callback) {
-
-    // TODO implement updating of project to new Crosswalk version.
-    // This function is not supported yet.
-    this.output.log("DemoPlatform: Updating project\n");
-
-    // Null means success, error string means failure.
-    callback(null);
-};
-
-DemoPlatform.prototype.refresh =
-function(callback) {
-
-    // TODO implement updating of project to new Crosswalk version.
-    // Maybe this function will be not needed, and removed in the future.
-    this.output.log("DemoPlatform: Refreshing project\n");
 
     // Null means success, error string means failure.
     callback(null);

--- a/src/CommandParser.js
+++ b/src/CommandParser.js
@@ -49,10 +49,6 @@ function() {
 "                                                Defaults to \"debug\" when not given\n" +
 "                                                Tries to build in current dir by default\n" +
 "\n" +
-"    crosswalk-app update [<version>] [<dir>]    Update Crosswalk to latest in named\n" +
-"                                                channel, or specific version\n" +
-"                                                Version is \"stable\" when not given" +
-"\n" +
 "    crosswalk-app platforms                     List available target platforms\n" +
 "\n" +
 "    crosswalk-app help                          Display usage information\n" +
@@ -73,13 +69,6 @@ function() {
     case "create":
         var packageId = this.createGetPackageId();
         return packageId !== null ? cmd : null;
-    case "update":
-        var version = this.updateGetVersion();
-        if (!version) {
-            // Error: version could not be parsed.
-            return null;
-        }
-        return cmd;
     case "build":
         var type = this.buildGetType();
         return type !== null ? cmd : null;
@@ -98,7 +87,7 @@ function() {
 
 /**
  * Get primary command.
- * @returns {String} One of "create", "update", "refresh", "build" or null.
+ * @returns {String} Returns command if valid, or null.
  */
 CommandParser.prototype.peekCommand =
 function() {
@@ -117,7 +106,7 @@ function() {
         return "help";
     }
 
-    if (["check", "manifest", "create", "update", "refresh", "build", "platforms"].indexOf(command) > -1) {
+    if (["check", "manifest", "create", "build", "platforms"].indexOf(command) > -1) {
         return command;
     }
 
@@ -168,30 +157,6 @@ function() {
     return packageId;
 };
 
-/**
- * Get version when command is "update".
- * @returns {String} Crosswalk version string when given and valid. Null when not given, false when invalid.
- * @see {@link https://crosswalk-project.org/documentation/downloads.html}
- */
-CommandParser.prototype.updateGetVersion =
-function() {
-
-    // argv is filled like this:
-    // node crosswalk-app update [version] [dir]
-    // So argv[3] is either version or dir.
-
-    if (this._argv.length < 4) {
-        return "stable";
-    }
-
-    var version = this._argv[3];
-    if (CommandParser.validateVersion(version, null)) {
-        return version;
-    }
-
-    return null;
-};
-
 // FIXME require node 0.12 and use Path.isAbsolute
 CommandParser.prototype.isAbsolute =
 function(path) {
@@ -203,30 +168,6 @@ function(path) {
 
     // Windows
     return path.match(/^[a-zA-z]:/) !== null;
-};
-
-/**
- * Get dir when command is "update". Defaults to current dir.
- */
-CommandParser.prototype.updateGetDir =
-function() {
-
-    // argv is filled like this:
-    // node crosswalk-app update [version] [dir]
-    // Dir can only be specified if version is given, though,
-    // no guessing around here.
-
-    if (this._argv.length < 5) {
-        // Dir not given.
-        return process.cwd();
-    }
-
-    var path = this._argv[4];
-    if (this.isAbsolute(path)) {
-        return Path.resolve(Path.normalize(path));
-    }
-
-    return Path.resolve(Path.normalize(Path.join(process.cwd(), path)));
 };
 
 /**

--- a/src/Main.js
+++ b/src/Main.js
@@ -300,46 +300,6 @@ function(packageId, extraArgs, callback) {
 };
 
 /**
- * Update crosswalk in the application package.
- * @param {String} version Version to update to, or null for latest stable version
- * @param {Object} extraArgs Unparsed extra arguments passed by command-line
- * @param {Main~mainOperationCb} callback Callback function
- * @static
- */
-Main.prototype.update =
-function(version, extraArgs, callback) {
-
-    var output = this.output;
-
-    var project = this.instantiatePlatform();
-    if (!project) {
-        callback(Main.EXIT_CODE_ERROR);
-        return;
-    }
-
-    // Collect args for this command
-    var updateArgs = {};
-    var argSpec = project.argSpec;
-    if (argSpec && argSpec.update) {
-        updateArgs = this.collectArgs(project.platformId, extraArgs, argSpec.update);
-    }
-
-    project.update(version, updateArgs, function(errormsg) {
-
-        if (errormsg) {
-            output.error(errormsg);
-            // Print full path here, because we want to copy/paste it.
-            output.info("Logfiles at " + this.logPath);
-            callback(Main.EXIT_CODE_ERROR);
-            return;
-        } else {
-            callback(Main.EXIT_CODE_OK);
-            return;
-        }
-    }.bind(this));
-};
-
-/**
  * Build application package.
  * @param {String} configId Build "debug" or "release" configuration
  * @param {Object} extraArgs Unparsed extra arguments passed by command-line
@@ -509,15 +469,6 @@ function(callback) {
         // Chain up the constructor.
         Application.call(app, process.cwd(), packageId);
         app.create(packageId, extraArgs, callback);
-        break;
-
-    case "update":
-        var version = parser.updateGetVersion();
-        rootDir = parser.updateGetDir();
-
-        // Chain up the constructor.
-        Application.call(app, rootDir, null);
-        app.update(version, extraArgs, callback);
         break;
 
     case "build":

--- a/src/PlatformBase.js
+++ b/src/PlatformBase.js
@@ -210,27 +210,6 @@ function(packageId, args, callback) {
 };
 
 /**
- * Update platform project to latest Crosswalk.
- * @param {String} versionSpec Channel name or version to update to, format w.x.y.z
- * @param {Object} args Extra options for the command
- * @param {PlatformBase~platformBaseOperationCb} callback callback function
- */
-PlatformBase.prototype.update =
-function(versionSpec, args, callback) {
-
-    throw new Error("PlatformBase.update() not implemented.");
-};
-
-/**
- * Refresh platform project after environment changes.
- */
-PlatformBase.prototype.refresh =
-function() {
-
-    throw new Error("PlatformBase.refresh() not implemented.");
-};
-
-/**
  * Build application package.
  * @param {String} release Configuration identifier for the build
  * @param {Object} args Extra options for the command

--- a/test-util/TestPlatform.js
+++ b/test-util/TestPlatform.js
@@ -17,18 +17,6 @@ function TestPlatformScope(PlatformBase, baseData) {
         callback(null);
     };
 
-    TestPlatform.prototype.update =
-    function(versionSpec, args, callback) {
-        // Null means success, error string means failure.
-        callback(null);
-    };
-
-    TestPlatform.prototype.refresh =
-    function(callback) {
-        // Null means success, error string means failure.
-        callback(null);
-    };
-
     TestPlatform.prototype.build =
     function(configId, args, callback) {
         // Null means success, error string means failure.
@@ -43,9 +31,6 @@ TestPlatformScope.getArgs = function() {
         create: { // Extra options for command "create"
             foo: "Create option added by the platform",
             bar: "Another create option added by the platform"
-        },
-        update: { // Extra options for command "update"
-            baz: "Update option added by the platform"
         }
     };
 };

--- a/test/command-parser.js
+++ b/test/command-parser.js
@@ -33,9 +33,9 @@ exports.tests = {
 
     getCommand: function(test) {
 
-        test.expect(8);
+        test.expect(6);
 
-        var commands = ["create", "update", "refresh", "build", "help", "version"];
+        var commands = ["create", "build", "help", "version"];
         var argv = ["foo", "bar"];
         var cp1;
         var cmd1;
@@ -112,83 +112,6 @@ exports.tests = {
         test.equal(cp2.getCommand(), null);
         pkg2 = cp2.createGetPackageId();
         test.equal(pkg2, null);
-
-        test.done();
-    },
-
-    updateGetVersion: function(test) {
-
-        test.expect(8);
-
-        // No version, good test, default to "stable"
-        var argv0 = ["node", "foo", "update"];
-        var cp0 = new CommandParser(_output, argv0);
-
-        test.equal(cp0.getCommand(), "update");
-
-        var cmd0 = cp0.getCommand();
-        test.equal(cmd0, argv0[2]);
-
-        var version0 = cp0.updateGetVersion();
-        test.equal(version0, "stable");
-
-        // Good test
-        var argv1 = ["node", "foo", "update", "12.34.56.78"];
-        var cp1 = new CommandParser(_output, argv1);
-
-        test.equal(cp1.getCommand(), "update");
-
-        var cmd1 = cp1.getCommand();
-        test.equal(cmd1, argv1[2]);
-
-        var version1 = cp1.updateGetVersion();
-        test.equal(version1, argv1[3]);
-
-        // Bad test, invalid version
-        var argv2 = ["node", "foo", "update", "12.34.x6.78"];
-        var cp2 = new CommandParser(_output, argv2);
-
-        test.equal(cp2.getCommand(), null);
-
-        var version2 = cp2.updateGetVersion();
-        test.equal(version2, null);
-
-        test.done();
-    },
-
-    updateGetDir: function(test) {
-
-        test.expect(8);
-
-        // build inside project
-        var argv0 = ["node", "foo", "update"];
-        var cp0 = new CommandParser(_output, argv0);
-
-        test.equal(cp0.getCommand(), "update");
-
-        var cmd0 = cp0.getCommand();
-        test.equal(cmd0, argv0[2]);
-
-        var version0 = cp0.updateGetVersion();
-        test.equal(version0, "stable");
-
-        var dir0 = cp0.updateGetDir();
-        test.equal(dir0, process.cwd());
-
-        // command-line with dir specified
-        var argv1 = ["node", "foo", "update", "beta", "com.example.foo"];
-        var cp1 = new CommandParser(_output, argv1);
-
-        test.equal(cp1.getCommand(), "update");
-
-        var cmd1 = cp1.getCommand();
-        test.equal(cmd1, argv1[2]);
-
-        var version1 = cp1.updateGetVersion();
-        test.equal(version1, argv1[3]);
-
-        var dir1 = cp1.updateGetDir();
-        test.equal(dir1, Path.join(process.cwd(), argv1[4]));
 
         test.done();
     },

--- a/test/main.js
+++ b/test/main.js
@@ -125,50 +125,6 @@ exports.tests = {
         });
     },
 
-    update: function(test) {
-
-        test.expect(1);
-
-        // Good test.
-        var tmpdir = Util.createTmpDir();
-        ShellJS.pushd(tmpdir);
-
-        var app = require("../src/Main");
-        Application.call(app, tmpdir, _packageId);
-        // Create
-        app.create(_packageId, {}, function(errno) {
-
-            if (!errno) {
-                // Update
-                ShellJS.pushd(_packageId);
-                app.update("stable", null, function(errno) {
-
-                    if (!errno) {
-                        // Build
-                        app.build("debug", null, function(errno) {
-
-                            test.equal(errno, 0);
-                            ShellJS.popd();
-                            ShellJS.popd();
-                            ShellJS.rm("-rf", tmpdir);
-                            test.done();
-                        });
-                    } else {
-                        ShellJS.popd();
-                        ShellJS.popd();
-                        ShellJS.rm("-rf", tmpdir);
-                        test.done();
-                    }
-                });
-            } else {
-                ShellJS.popd();
-                ShellJS.popd();
-                ShellJS.rm("-rf", tmpdir);
-                test.done();
-            }
-        });
-    },
-
     listPlatforms: function(test) {
 
         // Prints to stdout, so just run the code to see if it breaks.

--- a/test/platform-base.js
+++ b/test/platform-base.js
@@ -57,7 +57,7 @@ exports.tests = {
 
     subclass: function(test) {
 
-        test.expect(4);
+        test.expect(2);
 
         var basePath = Util.createTmpDir();
         var application = new Application(basePath, _packageId);
@@ -69,14 +69,6 @@ exports.tests = {
         var platform = new TestPlatform(PlatformBase, platformData);
 
         platform.create(_platformId, null, function(errormsg) {
-            test.equal(errormsg, null);
-        });
-
-        platform.update(null, null, function(errormsg) {
-            test.equal(errormsg, null);
-        });
-
-        platform.refresh(function(errormsg) {
             test.equal(errormsg, null);
         });
 

--- a/test/platform-info.js
+++ b/test/platform-info.js
@@ -14,16 +14,13 @@ exports.tests = {
 
     args: function(test) {
 
-        test.expect(3);
+        test.expect(2);
 
         var platformInfo = new PlatformInfo(TestPlatform, "test");
 
         var createArgs = platformInfo.argSpec.create;
         test.equal(typeof createArgs["--test-foo"], "string");
         test.equal(typeof createArgs["--test-bar"], "string");
-
-        var updateArgs = platformInfo.argSpec.update;
-        test.equal(typeof updateArgs["--test-baz"], "string");
 
         test.done();
     },

--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -41,9 +41,6 @@ WinPlatform.getArgs = function() {
     return {
         create: { // Extra options for command "create"
             crosswalk: "\t\t\tPath to crosswalk zip"
-        },
-        update: { // Extra options for command "update"
-            crosswalk: "\t\t\tPath to crosswalk zip"
         }
     };
 };
@@ -149,46 +146,6 @@ function(packageId, args, callback) {
         output.info("Project template created at", this.platformPath);
         callback(null);
     }.bind(this));
-};
-
-/**
- * Implements {@link PlatformBase.update}
- */
-WinPlatform.prototype.update =
-function(versionSpec, args, callback) {
-
-    var output = this.output;
-
-    // Rename current dir for backup.
-    var oldPath = this.platformPath + ".bak";
-    ShellJS.mv(this.platformPath, oldPath);
-
-    var errormsg = null;
-    var crosswalkPath = args.crosswalk;
-    var ret = this.importCrosswalkFromDisk(crosswalkPath);
-    if (ret) {
-        // Delete old project
-        ShellJS.rm("-rf", oldPath);
-        output.info("Successfully imported", crosswalkPath);
-    } else {
-        // Restore previous project
-        ShellJS.rm("-rf", this.platformPath);
-        ShellJS.mv(oldPath, this.platformPath);
-        errormsg = "Updating project failed";
-    }
-
-    callback(errormsg);
-};
-
-WinPlatform.prototype.refresh =
-function(callback) {
-
-    // TODO implement updating of project to new Crosswalk version.
-    // Maybe this function will be not needed, and removed in the future.
-    this.output.log("WinPlatform: TODO Refreshing project\n");
-
-    // Null means success, error string means failure.
-    callback(null);
 };
 
 /**


### PR DESCRIPTION
Those commands are not needed any more, because with crosswalk-pkg a
new project is created every time. Commands "clean" and "refresh" were
not implemented yet anyway, close tickets in JIRA.

BUG=XWALK-4153, XWALK-5596