### PR TITLE
-pkg: Better argument handling

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -1381,8 +1381,8 @@ function(configId, args, callback) {
                     output.highlight("Package: " + closure.apks[i]);
                 }
                 if (configId === "release") {
-                    output.highlight("  Sign APKs before publishing: " +
-                                     "https://developer.android.com/tools/publishing/app-signing.html#signing-manually");
+                    output.highlight("APKs need to be signed before publishing, see");
+                    output.highlight("https://developer.android.com/tools/publishing/app-signing.html#signing-manually");
                 }
             }
             callback(errormsg);

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -26,11 +26,12 @@ var util = require("./util/index.js");
 var argv = Minimist(process.argv.slice(2));
 
 // Help
-if (!process.argv[2] ||
+if (process.argv.length < 3 ||
+    process.argv[2] === "help" ||
     argv.h ||
     argv.help) {
     help();
-    process.exit(0);
+    process.exit(cat.EXIT_CODE_OK);
 }
 
 // Version
@@ -38,15 +39,18 @@ if (argv.v ||
     argv.version) {
     var Package = require("../package.json");
     output.write(Package.version + "\n");
-    process.exit(0);
+    process.exit(cat.EXIT_CODE_OK);
 }
 
-// Check html app path
-var appPath = Path.resolve(Path.normalize(argv._[0]));
+// Check html app path.
+// Path needs to be the last argument.
+var appPath = Path.resolve(Path.normalize(process.argv[process.argv.length - 1]));
 if (ShellJS.test("-d", appPath)) {
     _highlight(output, "Packaging", appPath);
 } else {
     output.error("Directory does not exist: " + appPath);
+    output.error("Path to html app directory needs to be passed as final argument");
+    process.exit(cat.EXIT_CODE_ERROR);
 }
 
 // Determine packageId
@@ -103,10 +107,10 @@ function help() {
         "\n" +
         "  <options>\n" +
         '    -a --android="<android-conf>"    Extra configurations for Android\n' +
-        "    -c --crosswalk=<version-spec>    Runtime version\n" +
+        "    -c --crosswalk=<version-spec>    Specify Crosswalk version or path\n" +
         "    -h --help                        Print usage information\n" +
         "    -m --manifest=<package-id>       Fill manifest.json with default values\n" +
-        "    -p --platforms=<android|windows> Target platform\n" +
+        "    -p --platforms=<android|windows> Specify target platform\n" +
         "    -r --release=true                Build release packages\n" +
         "    -v --version                     Print tool version\n" +
         "\n" +


### PR DESCRIPTION
Always take last command-line parameter as html app directory. This
allows -r to be passed without value, e.g. crosswalk-pkg -r <path>.

BUG=XWALK-5592