### PR TITLE
Android: Derive activity name from package-id

### DIFF
--- a/android/data/AndroidManifest.xml.tpl
+++ b/android/data/AndroidManifest.xml.tpl
@@ -8,7 +8,7 @@
         android:hardwareAccelerated="true"
         android:label="{{ packageName }}"
         android:icon="@drawable/crosswalk">
-        <activity android:name=".MainActivity"
+        <activity android:name="{{ activityName }}"
                   android:theme="@style/AppTheme"
                   android:configChanges="orientation|keyboardHidden|keyboard|screenSize"
                   android:screenOrientation="unspecified"

--- a/android/lib/AndroidManifest.js
+++ b/android/lib/AndroidManifest.js
@@ -247,6 +247,32 @@ Object.defineProperty(AndroidManifest.prototype, "permissions", {
                       });
 
 /**
+ * activityClassName
+ * @member {String} activityClassName Name for main activity java class
+ * @instance
+ * @memberOf AndroidManifest
+ */
+Object.defineProperty(AndroidManifest.prototype, "activityClassName", {
+                      get: function() {
+                                var doc = this.read();
+                                var node = this.findApplicationNode(doc);
+                                if (node) {
+                                    var activityNode = this.findChildNode(node, "activity");
+                                    if (activityNode) {
+                                        var androidName = activityNode.getAttribute("android:name");
+                                        // Remove leading .
+                                        return androidName.split(".").pop();
+                                    } else {
+                                        this._output.warning("Did not find <activity> element in AndroidManifest.xml");
+                                    }
+                                } else {
+                                    this._output.warning("Did not find <application> element in AndroidManifest.xml");
+                                }
+                                return null;
+                           }
+                      });
+
+/**
  * Read AndroidManifest.xml
  * @returns {xmldom.Document} XML Document
  * @protected

--- a/android/lib/JavaActivity.js
+++ b/android/lib/JavaActivity.js
@@ -43,10 +43,11 @@ JavaActivity.pathForPackage = JavaActivity.prototype.pathForPackage;
  * Import java activity file from crosswalk zip release.
  * @param {adm-zip.ZipEntry} zipEntry Entry holding the activity
  * @param {String} packageId Package identifier for the project
+ * @param {String} activityClassName Class ame for the Activity
  * @returns {Boolean} true on success, otherwise false.
  */
 JavaActivity.prototype.importFromZip =
-function(zipEntry, packageId) {
+function(zipEntry, packageId, activityClassName) {
 
     var output = this._output;
 
@@ -72,7 +73,7 @@ function(zipEntry, packageId) {
         output.error("Failed to find template class '" + templateClass + "' in " + zipEntry.name);
         return false;
     }
-    templateData = templateData.replace(templateClass, "MainActivity");
+    templateData = templateData.replace(templateClass, activityClassName);
 
     // Always load app from manifest instead of index.html
     templateData = templateData.replace('loadAppFromUrl("file:///android_asset/www/index.html")',


### PR DESCRIPTION
The main java activity class was always named "MainActivity" in our
built apps, but for easier automated testing with QAs tools we want
to have the name be derived from the package-id. So for example for
package-id of "com.example.foo", we now derive the activity class
name as FooActivity, using the last component case-modified, with
"Activity" suffix.

BUG=XWALK-5014