### PR TITLE
Manifest, Android: Support manifest background_color

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -1062,6 +1062,12 @@ function(release, activityClassName) {
                              Path.join(this.platformPath, "res", "values-v14", "theme.xml"));
     theme.fullscreen = fullscreen;
 
+    // White is default, set colour if not white.
+    var bgColor = this.application.manifest.backgroundColor;
+    if (bgColor != "#ffffff") {
+        theme.setStartupBackgroundColor(bgColor);
+    }
+
     // "Keep screen on"
     ret = activity.enableKeepScreenOn(this.application.manifest.androidKeepScreenOn);
     if (!ret)

--- a/android/test/xml-theme.js
+++ b/android/test/xml-theme.js
@@ -27,9 +27,10 @@ function createTheme() {
 '\n' +
 '<resources>\n' +
 '    <!-- Application theme. -->\n' +
+'    <color name="white">#FFFFFFFF</color>\n' +
 '    <style name="AppTheme" parent="@android:style/Theme.Holo.Light.NoActionBar">\n' +
 '        <item name="android:windowFullscreen">false</item>\n' +
-'        <item name="android:windowBackground">@null</item>\n' +
+'        <item name="android:windowBackground">@color/white</item>\n' +
 '    </style>\n' +
 '</resources>\n';
 
@@ -39,6 +40,24 @@ function createTheme() {
 }
 
 exports.tests = {
+
+    background: function(test) {
+
+        test.expect(2);
+
+        var path = createTheme();
+        var theme = new XmlTheme(_output, path);
+        test.equal(theme.background, "@color/white");
+
+        // change and read back
+        theme.background = "@null";
+        theme = new XmlTheme(_output, path);
+        test.equal(theme.background, "@null");
+
+        ShellJS.rm("-f", path);
+
+        test.done();
+    },
 
     fullscreen: function(test) {
 

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "mktemp": "~0.3.5",
     "mustache": "~0.8.2",
     "node-uuid": "~1.4.3",
+    "parse-color": "~1.0.0",
     "readdir": "~0.0.13",
     "shelljs": "~0.3.0",
     "xmlbuilder": "~2.6.4",

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -6,6 +6,7 @@ var FS = require("fs");
 var Path = require("path");
 
 var FormatJson = require("format-json");
+var ParseColor = require('parse-color');
 var ShellJS = require("shelljs");
 
 var CommandParser = require("./CommandParser");
@@ -56,6 +57,17 @@ function Manifest(output, path) {
     if (!this._appVersion) {
         output.error("Invalid app version '" + json.xwalk_app_version + "' in the manifest");
         throw new Error("Invalid app version '" + json.xwalk_app_version + "' in the manifest");
+    }
+
+    // Splash background colour
+    this._backgroundColor = "#ffffff";
+    if (json.background_color) {
+        var color = ParseColor(json.background_color);
+        if (color && color.hex) {
+            this._backgroundColor = color.hex;
+        } else {
+            output.warning("Failed to parse background_color " + json.background_color);
+        }
     }
 
     // Name
@@ -296,6 +308,7 @@ function(packageId) {
         // Standard fields
         "name": packageId,
         "short_name": packageId.split(".").pop(),
+        "background_color": "#ffffff",
         "display": "standalone",
         "orientation": "any",
         "start_url": "index.html",
@@ -459,6 +472,19 @@ Object.defineProperty(Manifest.prototype, "shortName", {
                                     this._output.error(errormsg);
                                     throw new IllegalAccessException(errormsg);
                                 }
+                           }
+                      });
+
+/**
+ * Background color at launch time
+ * @member {String} backgroundColor
+ * @instance
+ * @memberOf Manifest
+ * @see http://www.w3.org/TR/appmanifest/#background_color-member
+ */
+Object.defineProperty(Manifest.prototype, "backgroundColor", {
+                      get: function() {
+                                return this._backgroundColor;
                            }
                       });
 

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -159,6 +159,33 @@ exports.tests = {
         test.done();
     },
 
+    backgroundColor: function(test) {
+
+        test.expect(8);
+
+        // Default to "standalone"
+        var path = produceManifest();
+        var manifest = consumeManifest(path);
+        test.equal(manifest.backgroundColor, "#ffffff");
+
+        // Test reading various values
+        var values =  ["#9", "#99", "#999", "#9999", "#99999", "#999999"];
+        values.forEach(function (value) {
+            path = produceManifest({"background_color": value});
+            manifest = consumeManifest(path);
+            // When value is different from default, we assume it has been
+            // parsed correctly.
+            test.equal(manifest.backgroundColor != "#ffffff", true);
+        });
+
+        // Test reading bogus value "foo", default to "standalone"
+        path = produceManifest({"background_color": "foo"});
+        manifest = consumeManifest(path);
+        test.equal(manifest.backgroundColor, "#ffffff");
+
+        test.done();
+    },
+
     display: function(test) {
 
         test.expect(6);


### PR DESCRIPTION
Default background_color is #ffffff (white). If a different colour
is set, it is displayed during the application startup, using the
"xwalk launch screen" theming infrastructure (theme.xml,
launchscreen_bg.xml).

Also add unit tests for Manifest, XmlTheme classes.

BUG=XWALK-5648