### PR TITLE
Android: Create target dirs only when importing zip, not dir

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -338,7 +338,6 @@ function(crosswalkPath, activityClassName) {
     entry = xwalk.getEntry(name);
     if (entry) {
         path = Path.join(this.platformPath, xwalkLibrary);
-        ShellJS.mkdir(path);
         xwalk.extractEntryTo(entry, path);
     } else {
         output.error("Failed to find entry " + name);

--- a/src/util/CrosswalkDir.js
+++ b/src/util/CrosswalkDir.js
@@ -121,7 +121,12 @@ function(path) {
 CrosswalkDir.prototype.extractEntryTo =
 function(entry, path) {
 
-    ShellJS.cp("-rf", entry.path, path);
+    var entryPath = entry.path;
+    if (ShellJS.test("-d", entry.path)) {
+        entryPath = Path.join(entry.path, "*");
+    }
+
+    ShellJS.cp("-rf", entryPath, path);
     return true;
 };
 

--- a/src/util/CrosswalkZip.js
+++ b/src/util/CrosswalkZip.js
@@ -73,6 +73,13 @@ function(path) {
 CrosswalkZip.prototype.extractEntryTo =
 function(entry, path) {
 
+    // If dir and path does not exist, create it,
+    // because adm-zip doesn't.
+    if (path[path.length - 1] === "/" &&
+        !ShellJS.test("-d", path)) {
+        ShellJS.mkdir(path);
+    }
+
     return this._adm.extractEntryTo(entry, path, false, true);
 };
 


### PR DESCRIPTION
Otherwise the semantics of zip extraction and ShellJS recursive
copy do not match.

BUG=XWALK-5823