### PR TITLE
Android: Exec "ant" without path

### DIFF
--- a/android/lib/AndroidSDK.js
+++ b/android/lib/AndroidSDK.js
@@ -205,7 +205,7 @@ function(release, callback) {
     }
 
     var exitStatus = { "code" : 0 };
-    ant += release ? " release" : " debug";
+    ant = "ant " + (release ? "release" : "debug");
     var child = ChildProcess.exec(ant);
 
     child.stdout.on("data", function(data) {


### PR DESCRIPTION
When there is a whitespace in the patch to apache ant, such as in
C:\Program Files\... then building packages fails. Instead just
exec "ant" without path, to avoid this problem.

BUG=XWALK-5894