### PR TITLE
-app: Take only single target --platform

### DIFF
--- a/src/CommandParser.js
+++ b/src/CommandParser.js
@@ -40,10 +40,10 @@ function() {
 "\n" +
 "    crosswalk-app manifest <path>               Initialize web manifest in <path>\n" +
 "                  --package-id=<package-id>     Canonical package name e.g. com.example.foo\n" +
-"                  --platforms=<target>          Optional, e.g. \"windows\"\n" +
+"                  --platform=<target>           Optional, e.g. \"windows\"\n" +
 "\n" +
 "    crosswalk-app create <package-id>           Create project <package-id>\n" +
-"                  --platforms=<target>          Optional, e.g. \"windows\"\n" +
+"                  --platform=<target>           Optional, e.g. \"windows\"\n" +
 "\n" +
 "    crosswalk-app build [release|debug] [<dir>] Build project to create packages\n" +
 "                                                Defaults to \"debug\" when not given\n" +

--- a/src/Manifest.js
+++ b/src/Manifest.js
@@ -175,14 +175,14 @@ function Manifest(output, path) {
 
     // Target platforms
     if (json.xwalk_target_platforms &&
-        typeof json.xwalk_target_platforms === "string") {
+        json.xwalk_target_platforms instanceof Array) {
         this._targetPlatforms = json.xwalk_target_platforms;
     }
 
     if (!this._targetPlatforms) {
         output.error("Missing or invalid target platforms in the manifest");
         output.error("Try adding");
-        output.error('    "xwalk_target_platforms": "android"');
+        output.error('    "xwalk_target_platforms": [ "android" ]');
         output.error("or similar for platform of choice.");
     }
 
@@ -316,7 +316,7 @@ function(packageId) {
         "xwalk_app_version": "0.1",
         "xwalk_command_line": "",
         "xwalk_package_id": packageId,
-        "xwalk_target_platforms": platformInfo.platformId,
+        "xwalk_target_platforms": [ platformInfo.platformId ],
         // Android fields
         "xwalk_android_animatable_view": false,
         "xwalk_android_keep_screen_on": false,
@@ -626,7 +626,7 @@ Object.defineProperty(Manifest.prototype, "extensions", {
 
 /**
  * Build target platforms for the apps
- * @member {String} targetPlatforms
+ * @member {String[]} targetPlatforms
  * @throws {IllegalAccessException} If unknown target platforms are set.
  * @instance
  * @memberOf Manifest
@@ -638,13 +638,13 @@ Object.defineProperty(Manifest.prototype, "targetPlatforms", {
                       set: function(targetPlatforms) {
                                 var PlatformsManager = require("./PlatformsManager");
                                 var mgr = new PlatformsManager(this._output);
-                                if (typeof targetPlatforms === "string" &&
-                                    mgr.load(targetPlatforms)) {
+                                var ret = targetPlatforms.every(function (platform) {
+                                    return mgr.load(platform);
+                                });
+                                if (ret) {
                                     this._targetPlatforms = targetPlatforms;
                                     this.update({"xwalk_target_platforms": this._targetPlatforms});
                                 } else {
-                                    var errormsg = "Target platform '" + targetPlatforms + "' not available";
-                                    this._output.error(errormsg);
                                     throw new IllegalAccessException(errormsg);
                                 }
                            }

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -317,7 +317,7 @@ function copy(app, appPath, extraArgs, callback) {
 
     // Propagate target platform cause we just nuked the manifest
     if (extraArgs.platforms.length > 0) {
-        app.manifest.targetPlatforms = extraArgs.platforms[0];
+        app.manifest.targetPlatforms = extraArgs.platforms;
     }
 
     callback(cat.EXIT_CODE_OK);

--- a/test/main.js
+++ b/test/main.js
@@ -110,7 +110,7 @@ exports.tests = {
 
                 // Build
                 ShellJS.pushd(_packageId);
-                app.build("debug", null, function(errno) {
+                app.build("debug", {}, function(errno) {
 
                     test.equal(errno, 0);
                     test.done();

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -329,18 +329,18 @@ exports.tests = {
 
         test.expect(2);
 
-        var path = produceManifest({"xwalk_target_platforms": "android"});
+        var path = produceManifest({"xwalk_target_platforms": [ "android" ] });
 
         // read
         var manifest = new Manifest(_output, path);
-        test.equal(manifest.targetPlatforms, "android");
+        test.equal(manifest.targetPlatforms[0], "android");
 
         // write
-        manifest.targetPlatforms = "windows";
+        manifest.targetPlatforms = [ "windows" ];
 
         // read back
         manifest = consumeManifest(path);
-        test.equal(manifest.targetPlatforms, "windows");
+        test.equal(manifest.targetPlatforms[0], "windows");
 
         test.done();
     },


### PR DESCRIPTION
Also internal clean up so that crosswalk-app will be able to build
only for single target platforms, while crosswalk-pkg will support
multiple targets.

BUG=XWALK-5909