### PR TITLE
Remove unnecessary node_modules/grunt-cli/bin/ path from npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "crosswalk-pkg": "./src/crosswalk-pkg"
   },
   "scripts": {
-    "test": "node_modules/grunt-cli/bin/grunt test"
+    "test": "grunt test"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The ```node_modules/grunt-cli/bin/``` path in the npm test command is unncessary and makes ```npm test``` fail on Windows hosts. Removing it solves that problem.

Tested that ```npm test``` still works on OS X.