### PR TITLE
Windows: Enable inspector for debug builds

### DIFF
--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -212,6 +212,10 @@ function(configId, args, callback) {
     var output = this.output;
     var manifest = this.application.manifest;
 
+    if (!configId) {
+        configId = "debug";
+    }
+
     // WiX wants 4 component version numbers, so append as many ".0" as needed.
     // Manifest versions are restricted to 4 parts max.
     var nComponents = manifest.appVersion.split(".").length;
@@ -243,6 +247,7 @@ function(configId, args, callback) {
     }.bind(this);
 
     var metaData = {
+        configId: configId,
         app_name: manifest.name,
         upgrade_id: manifest.windowsUpdateId,
         manufacturer: this.getVendor(),

--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -242,6 +242,7 @@ function(app_path, xwalk_path, meta_data, callback) {
 
     var program_menu_folder_ref = product.ele('DirectoryRef', { Id: 'ApplicationProgramsFolder' });
     var component = program_menu_folder_ref.ele('Component', { Id: 'ApplicationShortcut', Guid: uuid.v1() });
+
     var cmd_line_args = InQuotes(path.join(meta_data.app_name, 'manifest.json'));
     if (this._manifest.commandLine) {
         var manifest_args = this._manifest.commandLine.split(" ").reduce(function (acc, val) {
@@ -255,6 +256,10 @@ function(app_path, xwalk_path, meta_data, callback) {
     }
     if (HasExtensions())
         cmd_line_args += ' --external-extensions-path=extensions';
+    if (meta_data.configId === "debug") {
+        cmd_line_args += " --enable-inspector";
+    }
+
     var shortcut = component.ele('Shortcut', {
         Id: 'ApplicationStartMenuShortcut',
         Name: meta_data.app_name,


### PR DESCRIPTION
When not explicitely building a release MSI, right-click on the
crosswalk app shows a menu to launch the chromium inspector.

BUG=XWALK-5188