### PR TITLE
test: refactor test sources and run Windows tests if platform is Windows

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,7 +4,9 @@ module.exports = function(grunt) {
     pkg: grunt.file.readJSON('package.json'),
 
     nodeunit: {
-      all: ['test/*.js', 'android/test/*.js'],
+      common: 'test/*.js',
+      android: 'android/test/*.js',
+      windows: process.platform == 'win32' ? 'windows/test/*.js' : 'undefined',
       options: {
         reporter: 'default',
         reporterOptions: {

--- a/android/test/main.js
+++ b/android/test/main.js
@@ -1,0 +1,66 @@
+// Copyright © 2014 Intel Corporation. All rights reserved.
+// Use  of this  source  code is  governed by  an Apache v2
+// license that can be found in the LICENSE-APACHE-V2 file.
+
+var OS = require('os');
+var ShellJS = require("shelljs");
+
+var Application = require("../../src/Application");
+var Util = require("../../test-util/Util.js");
+
+var _packageId = "com.example.foo";
+
+exports.tests = {
+
+    create: function(test) {
+
+        test.expect(1);
+
+        // Good test.
+        var tmpdir = Util.createTmpDir();
+        ShellJS.pushd(tmpdir);
+
+        var app = require("../../src/Main");
+        Application.call(app, tmpdir, _packageId);
+        app.create(_packageId, {}, function(errno) {
+
+            test.equal(errno, 0);
+
+            ShellJS.popd();
+            ShellJS.rm("-rf", tmpdir);
+
+            test.done();
+        });
+    },
+
+    build: function(test) {
+
+        test.expect(1);
+
+        // Create
+        var tmpdir = Util.createTmpDir();
+        ShellJS.pushd(tmpdir);
+
+        var app = require("../../src/Main");
+        Application.call(app, tmpdir, _packageId);
+        app.create(_packageId, {}, function(errno) {
+
+            if (!errno) {
+
+                // Build
+                ShellJS.pushd(_packageId);
+                app.build("debug", {}, function(errno) {
+
+                    test.equal(errno, 0);
+                    test.done();
+
+                    ShellJS.popd();
+                    ShellJS.popd();
+                    ShellJS.rm("-rf", tmpdir);
+                });
+            } else {
+                test.done();
+            }
+        });
+    },
+};

--- a/test/main.js
+++ b/test/main.js
@@ -73,58 +73,6 @@ exports.tests = {
         });
     },
 
-    create: function(test) {
-
-        test.expect(1);
-
-        // Good test.
-        var tmpdir = Util.createTmpDir();
-        ShellJS.pushd(tmpdir);
-
-        var app = require("../src/Main");
-        Application.call(app, tmpdir, _packageId);
-        app.create(_packageId, {}, function(errno) {
-
-            test.equal(errno, 0);
-
-            ShellJS.popd();
-            ShellJS.rm("-rf", tmpdir);
-
-            test.done();
-        });
-    },
-
-    build: function(test) {
-
-        test.expect(1);
-
-        // Create
-        var tmpdir = Util.createTmpDir();
-        ShellJS.pushd(tmpdir);
-
-        var app = require("../src/Main");
-        Application.call(app, tmpdir, _packageId);
-        app.create(_packageId, {}, function(errno) {
-
-            if (!errno) {
-
-                // Build
-                ShellJS.pushd(_packageId);
-                app.build("debug", {}, function(errno) {
-
-                    test.equal(errno, 0);
-                    test.done();
-
-                    ShellJS.popd();
-                    ShellJS.popd();
-                    ShellJS.rm("-rf", tmpdir);
-                });
-            } else {
-                test.done();
-            }
-        });
-    },
-
     listPlatforms: function(test) {
 
         // Prints to stdout, so just run the code to see if it breaks.


### PR DESCRIPTION
The main purpose of this PR is to run Windows tests when ```npm test``` is running on Windows, in addition to the Android tests. To achieve this:

* build and create Android tests are moved out of ```test/main.js```. The top-level ```test``` folder only includes platform-agnostic tests
* build and create Android tests are added to ```android/test/main.js```
* ```Gruntfile.js``` contains three subtasks for the nodeunit task, ```common```, ```android``` and ```windows```. They can be run individually with e.g. ```grunt nodeunit:common```, or all at once with ```grunt nodeunit``` (what ```npm test``` does)
* The ```windows``` task is empy if not running on windows

BUG=XWALK-5955