### PR TITLE
Enable CI for Linux host on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: android
+
+android:
+  components:
+    - build-tools-22.0.1
+
+before_script:
+  - npm install
+
+script:
+  - npm test


### PR DESCRIPTION
Enable integration with the Travis CI infrastructure (www.travis-ci.org).

After this PR is merged, any push to the repository will trigger common and Android unit test on Linux host. Results will be visible at https://travis-ci.org/crosswalk-project/crosswalk-app-tools

Test runs will be triggered on PR submission as well, but ONLY if the PR is from a branch within the same upstream repository. This is a restriction imposed by Travis for security reasons.

Related to (but doesn't completely fix) XWALK-5889 