### PR TITLE
Enable CI on Windows hosts with Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,33 @@
+# Test against this version of Node.js
+# environment:
+#   nodejs_version: "0.10"
+cache:
+- C:\apache-ant-1.9.6-bin.zip
+
+environment:
+  ANDROID_HOME: C:\Program Files (x86)\Android\android-sdk
+  ANT_HOME: C:\apache-ant-1.9.6
+  WIX_HOME: C:\Program Files (x86)\WiX Toolset v3.10
+
+# Install scripts. (runs after repo cloning)
+install:
+  # Get the latest stable version of Node.js or io.js
+ # - ps: Install-Product node $env:nodejs_version
+  # install modules
+  - cd \
+  - appveyor DownloadFile http://www.eu.apache.org/dist//ant/binaries/apache-ant-1.9.6-bin.zip
+  - 7z x apache-ant-1.9.6-bin.zip > nul
+  - set PATH=%ANDROID_HOME%\tools;%PATH%;%ANT_HOME%\bin;%WIX_HOME%\bin
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - npm install
+
+# Post-install test scripts.
+test_script:
+  # Output useful info for debugging.
+  - node --version
+  - npm --version
+  # run tests
+  - npm test
+
+# Don't actually build.
+build: off


### PR DESCRIPTION
Enable integration with the Appveyor CI infrastructure (www.appveyor.com).

After this PR is merged, any push to the repository will trigger common, Android and Windows unit tests on Windows host. Results will be visible at https://ci.appveyor.com/project/crosswalk-project/crosswalk-app-tools.

Test runs will be triggered on PR submission as well.

Related to (but doesn't completely fix) XWALK-5889