### PR TITLE
Windows: Support packaging of external extensions by manifest file

### DIFF
--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -255,7 +255,6 @@ function(configId, args, callback) {
         is_64_bit: true,
         icon: this.selectIcon(),
         product: manifest.packageId
-        //extensions: 'tests/extension/echo_extension'
     };
     sdk.generateMSI(this.appPath, this.platformPath, metaData,
                     function (success) {


### PR DESCRIPTION
Combine all the extensions into "xwalk-extensions" sub-directory
of the packaged application.

BUG=XWALK-4851