### PR TITLE
Enable QA tests for Travis and Appveyor CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,62 @@
-language: android
+sudo: required
 
-android:
-  components:
-    - build-tools-22.0.1
+matrix:
+  include:
+    - language: objective-c
+      os: osx
+      osx_image: xcode7.1
+      script:
+        - grunt nodeunit:common
+    - language: objective-c
+      os: osx
+      osx_image: xcode7.1
+      script:
+        - python lint.py -p ios
+    - language: android      
+      android:
+        components:
+          - build-tools-22.0.1
+      script:
+        - npm test
+    - language: android      
+      android:
+        components:
+          - build-tools-22.0.1
+      install:
+        - echo no | android create avd --force -n test -t android-21 --abi armeabi-v7a
+        - emulator -avd test -no-skin -no-audio -no-window &
+        - android-wait-for-emulator
+        - adb devices
+      script:
+        - python lint.py -p android -a 32bit
+    - language: android      
+      android:
+        components:
+          - build-tools-22.0.1
+      script:
+        - python lint.py -p android -a 64bit
 
 before_script:
-  - npm install
-
-script:
-  - npm test
+  - if [ $TRAVIS_OS_NAME == "linux" ]; then
+      npm install;
+      npm install exec-sync;
+      sudo pip install BeautifulSoup4;
+    fi
+  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+      npm cache clean -f;
+      npm install -g n;
+      n 4.2.1;
+      npm uninstall -g grunt;
+      npm install -g grunt-cli;
+      npm install;
+      cd node_modules;
+      git clone https://github.com/crosswalk-project/crosswalk-app-tools-ios.git crosswalk-app-tools-backend-ios;
+      cd crosswalk-app-tools-backend-ios;
+      npm install;
+      cd ../../;
+      wget http://www.crummy.com/software/BeautifulSoup/bs4/download/4.4/beautifulsoup4-4.4.1.tar.gz;
+      tar -xvf beautifulsoup4-4.4.1.tar.gz;
+      cd beautifulsoup4-4.4.1;
+      sudo python setup.py install;
+      cd ../;
+    fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,33 +1,47 @@
-# Test against this version of Node.js
-# environment:
-#   nodejs_version: "0.10"
 cache:
 - C:\apache-ant-1.9.6-bin.zip
 
 environment:
-  ANDROID_HOME: C:\Program Files (x86)\Android\android-sdk
-  ANT_HOME: C:\apache-ant-1.9.6
-  WIX_HOME: C:\Program Files (x86)\WiX Toolset v3.10
+  matrix:
+    - ANDROID_HOME: C:\Program Files (x86)\Android\android-sdk
+      ANT_HOME: C:\apache-ant-1.9.6
+      TEST_SCRIPT: "nodeunit_test"
+    - WIX_HOME: C:\Program Files (x86)\WiX Toolset v3.10
+      TEST_SCRIPT: "windows_test"
+    - ANDROID_HOME: C:\Program Files (x86)\Android\android-sdk
+      ANT_HOME: C:\apache-ant-1.9.6
+      TEST_SCRIPT: "android_test"
 
-# Install scripts. (runs after repo cloning)
 install:
-  # Get the latest stable version of Node.js or io.js
- # - ps: Install-Product node $env:nodejs_version
-  # install modules
   - cd \
   - appveyor DownloadFile http://www.eu.apache.org/dist//ant/binaries/apache-ant-1.9.6-bin.zip
   - 7z x apache-ant-1.9.6-bin.zip > nul
-  - set PATH=%ANDROID_HOME%\tools;%PATH%;%ANT_HOME%\bin;%WIX_HOME%\bin
+  - md lzma
+  - cd lzma
+  - appveyor DownloadFile http://www.7-zip.org/a/lzma1514.7z
+  - 7z x lzma1514.7z
+  - cd ..\
+  - set PATH=%ANDROID_HOME%\tools;%PATH%;%ANT_HOME%\bin;%WIX_HOME%\bin;C:\lzma\bin;
+  - appveyor DownloadFile http://www.crummy.com/software/BeautifulSoup/bs4/download/4.4/beautifulsoup4-4.4.1.tar.gz
+  - 7z x beautifulsoup4-4.4.1.tar.gz
+  - 7z x dist/beautifulsoup4-4.4.1.tar > nul
+  - cd beautifulsoup4-4.4.1
+  - python setup.py install
   - cd %APPVEYOR_BUILD_FOLDER%
   - npm install
 
-# Post-install test scripts.
 test_script:
-  # Output useful info for debugging.
-  - node --version
-  - npm --version
-  # run tests
-  - npm test
+  - if "%TEST_SCRIPT%" == "nodeunit_test" (
+      npm test
+    )
+  - if "%TEST_SCRIPT%" == "windows_test" (
+      python lint.py -p windows
+    )
+  - if "%TEST_SCRIPT%" == "android_test" (
+      python lint.py -p android -a 32bit
+    )
+  - if "%TEST_SCRIPT%" == "android_test" (
+      python lint.py -p android -a 64bit
+    )
 
-# Don't actually build.
 build: off

--- a/lint.py
+++ b/lint.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+import os
+import sys
+import commands
+import shutil
+from optparse import OptionParser
+import urllib2
+import re
+from bs4 import BeautifulSoup
+import platform
+
+SCRIPT_PATH = os.path.dirname(os.path.realpath(__file__))
+crosswalk_test_suite = os.path.join(SCRIPT_PATH, "crosswalk-test-suite")
+tmp = os.path.join(SCRIPT_PATH, "tmp")
+apptools = os.path.join(crosswalk_test_suite, "apptools")
+apptools_android_tests = os.path.join(tmp, "apptools-android-tests")
+apptools_windows_tests = os.path.join(tmp, "apptools-windows-tests")
+apptools_ios_tests = os.path.join(tmp, "apptools-ios-tests")
+
+os.environ['CROSSWALK_APP_SRC'] = os.path.join(SCRIPT_PATH, "src") + "/"
+
+returnCode = 0
+if os.path.exists(crosswalk_test_suite):
+    os.chdir(crosswalk_test_suite)
+    cmd = 'git pull'
+    returnCode = os.system(cmd)
+    os.chdir(SCRIPT_PATH)
+else:
+    cmd = 'git clone https://github.com/crosswalk-project/crosswalk-test-suite'
+    returnCode = os.system(cmd)
+if returnCode == 1:
+    sys.exit(1)
+
+if os.path.exists(tmp):
+    shutil.rmtree(tmp)
+
+def crosswalk_version(channel, platform):
+    htmlDoc = urllib2.urlopen(
+        'https://download.01.org/crosswalk/releases/crosswalk/' + platform + '/' +
+        channel +
+        '/').read()
+    soup = BeautifulSoup(htmlDoc)
+    alist = soup.find_all('a')
+    version = ''
+    for  index in range(-1, -len(alist)-1, -1):
+        aEle = alist[index]
+        version = aEle['href'].strip('/')
+        if re.search('[0-9]*\.[0-9]*\.[0-9]*\.[0-9]*', version):
+            break
+    return version
+
+def main():
+    usage = "Usage: ./lint.py -p android"
+    opts_parser = OptionParser(usage=usage)
+    opts_parser.add_option(
+        "-p",
+        dest="platform",
+        help="specify the testsuit platform, e.g. android, windows, ios")
+    opts_parser.add_option(
+        "-a",
+        dest="arch",
+        help="specify the packing apk bit, e.g. 32bit, 64bit")
+    global BUILD_PARAMETERS
+    (BUILD_PARAMETERS, args) = opts_parser.parse_args()
+    if BUILD_PARAMETERS.platform == "android":
+        os.environ['CROSSWALK_APP_TOOLS_CACHE_DIR'] = os.path.join(apptools_android_tests, "tools")
+        x = []
+        for i in list(os.popen('adb devices -l'))[1:]:
+            if i.strip(os.linesep) != "" and i.strip(os.linesep).split(" ")[0] != "*":
+                x.append(i.strip(os.linesep).split(" ")[0])
+        if x:
+            os.environ['DEVICE_ID'] = ",".join(x)
+        os.environ['SKIP_EMULATOR'] = "True"
+        android_crosswalk_version = crosswalk_version("stable", BUILD_PARAMETERS.platform)
+        shutil.copytree(os.path.join(apptools, "apptools-android-tests"), apptools_android_tests)
+        fp = open(apptools_android_tests + '/arch.txt', 'w+')
+        fp.write("arm")
+        fp.close()
+        if platform.system() != "Linux":
+            hp = open(apptools_android_tests + "/host.txt", 'w+')
+            hp.write("Windows")
+            hp.close()
+        else:
+            hp = open(apptools_android_tests + "/host.txt", 'w+')
+            hp.write("Android")
+            hp.close()
+        if BUILD_PARAMETERS.arch == "64bit":
+            vp_64 = open(apptools_android_tests + "/version.txt", 'w+')
+            vp_64.write(android_crosswalk_version + " 64")
+            vp_64.close()
+            os.chdir(os.path.join(apptools_android_tests, "tools"))
+            if platform.system() != "Linux":
+                os.system("appveyor DownloadFile https://download.01.org/crosswalk/releases/crosswalk/" + BUILD_PARAMETERS.platform + "/stable/" + android_crosswalk_version + "/crosswalk-" + android_crosswalk_version + "-64bit.zip")
+            else:
+                os.system("wget https://download.01.org/crosswalk/releases/crosswalk/" + BUILD_PARAMETERS.platform + "/stable/" + android_crosswalk_version + "/crosswalk-" + android_crosswalk_version + "-64bit.zip")
+        else:
+            vp_32 = open(apptools_android_tests + "/version.txt", 'w+')
+            vp_32.write(android_crosswalk_version + " 32")
+            vp_32.close()
+            os.chdir(os.path.join(apptools_android_tests, "tools"))
+            if platform.system() != "Linux":
+                os.system("appveyor DownloadFile https://download.01.org/crosswalk/releases/crosswalk/" + BUILD_PARAMETERS.platform + "/stable/" + android_crosswalk_version + "/crosswalk-" + android_crosswalk_version + ".zip")
+            else:
+                os.system("wget https://download.01.org/crosswalk/releases/crosswalk/" + BUILD_PARAMETERS.platform + "/stable/" + android_crosswalk_version + "/crosswalk-" + android_crosswalk_version + ".zip")
+        os.chdir(os.path.join(os.path.join(apptools_android_tests, "apptools"), "CI"))
+        if platform.system() != "Linux":
+            os.system("python -m unittest discover --pattern=crosswalk_pkg_basic.py > null")
+        else:
+            os.system("python -m unittest discover --pattern=*.py > null")
+    elif BUILD_PARAMETERS.platform == "windows":
+        os.environ['CROSSWALK_APP_TOOLS_CACHE_DIR'] = os.path.join(apptools_windows_tests, "tools")
+        shutil.copytree(os.path.join(apptools, "apptools-windows-tests"), apptools_windows_tests)
+        os.chdir(os.path.join(apptools_windows_tests, "tools"))
+        windows_crosswalk_version = crosswalk_version("canary", BUILD_PARAMETERS.platform)
+        os.system("appveyor DownloadFile https://download.01.org/crosswalk/releases/crosswalk/" + BUILD_PARAMETERS.platform + "/canary/" + windows_crosswalk_version + "/crosswalk-" + windows_crosswalk_version + ".zip")
+        os.chdir(os.path.join(os.path.join(apptools_windows_tests, "apptools"), "CI"))
+        os.system("python -m unittest discover --pattern=*.py > null")
+    elif BUILD_PARAMETERS.platform == "ios":
+        shutil.copytree(os.path.join(apptools, "apptools-ios-tests"), apptools_ios_tests)
+        os.chdir(os.path.join(os.path.join(apptools_ios_tests, "apptools"), "CI"))
+        os.system("python -m unittest discover --pattern=*.py > null")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Failure analysis:
https://crosswalk-project.org/jira/browse/XWALK-5171

- Enable 26 QA android 32-bits tests for Linux host on Travis-CI
- Enable 26 QA android 64-bits tests for Linux host on Travis-CI
- Enable 9 QA ios tests for OSX host on Travis-CI
- Enable ios nodeunit tests for OSX host on Travis-CI by command: 'grunt nodeunit:common'
- Enable 15 QA windows tests on Appveyor
- Enable 10 QA android 32-bits tests on Appveyor
- Enable 10 QA android 64-bits tests on Appveyor
- Android 64-bit testing on travis and android testing on appveyor are blocked by emulator issue, we skip checkpoints of emulator dependency
- Android 32bit and 64bit testing on appveyor waste too much time, we reduce the crosswalk-app tests

https://crosswalk-project.org/jira/browse/XWALK-5889