### PR TITLE
Android: Fix handling of -t / --targets parameter

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -421,7 +421,7 @@ function(targetsSpec) {
         });
     }
 
-    return undefined;
+    return targetsSpec;
 };
 
 /**


### PR DESCRIPTION
Targets support for crosswalk-app broke the default behaviour by
overriding already parsed targets with undefined. Fix return
value to respect existing value.

Oh boy. Most stupdid bug of 2016 already.

BUG=XWALK-6016