### PR TITLE
-pkg: Ignore -t / --targets for shared android build

### DIFF
--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -391,6 +391,18 @@ if (argv.a) {
 if (argv.android) {
     extraArgs.android = argv.android;
 }
+if (extraArgs.android) {
+
+    var androidArgs = extraArgs.android.split(" ");
+    if (androidArgs.indexOf("shared") > -1 &&
+        (argv.t || argv.targets)) {
+
+        output.warning("Ignoring -t / --targets for shared android build");
+        delete argv.t;
+        delete argv.targets;
+    }
+
+}
 
 // Crosswalk, see help for <version-spec>
 if (argv.c) {


### PR DESCRIPTION
The combination of shared and 64bit is undefined, shared is always
ABI independent.

BUG=XWALK-6213