### PR TITLE
Android: Improve permissions handling

### DIFF
--- a/android/lib/AndroidManifest.js
+++ b/android/lib/AndroidManifest.js
@@ -238,7 +238,12 @@ Object.defineProperty(AndroidManifest.prototype, "permissions", {
                                 this._output.info("Adding permissions " + permissions.join(","));
                                 permissions.forEach(function (permission) {
                                     child = doc.createElement("uses-permission");
-                                    child.setAttribute("android:name", "android.permission." + permission);
+                                    if (permission.indexOf(".") < 0) {
+                                        // If permission is not namespaced, use Android namespace
+                                        child.setAttribute("android:name", "android.permission." + permission);
+                                    } else {
+                                        child.setAttribute("android:name", permission);
+                                    }
                                     doc.documentElement.appendChild(child);
                                 });
 


### PR DESCRIPTION
By default, xwalk_android_permissions from manifest.json are added
to AndroidManifest.xml with a namespace of android.permission. But
if permissions already have a namespace, keep it, and do not add
the android one too.

BUG=XWALK-6214