### PR TITLE
Windows: Fix download after release filename change

### DIFF
--- a/src/util/Download01Org.js
+++ b/src/util/Download01Org.js
@@ -202,7 +202,9 @@ function(version) {
 
     var filename;
 
-    if (this._androidWordSize == 64) {
+    if (this._platform === "windows") {
+        filename = "crosswalk64-" + version + ".zip";
+    } else if (this._androidWordSize == 64) {
         filename = "crosswalk-" + version + "-64bit.zip";
     } else {
         filename = "crosswalk-" + version + ".zip";


### PR DESCRIPTION
Windows releases now start with crosswalk64-, so take that into
account when fetching the zip. This change came with the automated
windows builds.

BUG=XWALK-6567