### PR TITLE
Windows: Fix building against crosswalk dir

### DIFF
--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -103,7 +103,7 @@ function(crosswalkPath) {
     if (ShellJS.test("-d", crosswalkPath)) {
         ShellJS.mkdir(this.platformPath);
         ShellJS.cp(Path.join(crosswalkPath, "*"), this.platformPath);
-        version = util.Version.createFromPath(crosswalkPath);
+        version = util.Version.createFromFile(Path.join(crosswalkPath, "VERSION"));
     } else {
         var xwalk = new util.CrosswalkZip(crosswalkPath);
         var entry = xwalk.getEntry(xwalk.root);


### PR DESCRIPTION
App-tools supports building against an unzipped crosswalk release.
The dirname needs to passed through -c. This feature was broken
with the recent auto-build changing filename from crosswalk-<version>
to crosswalk64-<version>.

This change derives the crosswalk version from the VERSION file
inside, rather than the directory name, so it works again.

BUG=XWALK-6596