### PR TITLE
Windows: Create WiX wxs file in project root

### DIFF
--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -239,7 +239,7 @@ function(configId, args, callback) {
     var nComponents = manifest.appVersion.split(".").length;
     var versionPadding = new Array(4 - nComponents + 1).join(".0");
 
-    var sdk = new WixSDK(manifest, this.output);
+    var sdk = new WixSDK(this.application.rootPath, manifest, this.output);
     var indicator = output.createInfiniteProgress("Building package");
     sdk.onData = function(data) {
         this.logOutput.write(data);


### PR DESCRIPTION
Create the .wxs file in the project root directory rather than
current dir, so extension hooks can access, modify and repackage.

BUG=XWALK-6606