### PR TITLE
[Windows] Set the System.AppUserModel.ID on the shortcut

### DIFF
--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -309,6 +309,12 @@ function(app_path, xwalk_path, meta_data, callback) {
         Arguments: cmd_line_args,
         WorkingDirectory: 'ApplicationRootFolder'
     });
+    
+    shortcut.ele('ShortcutProperty', {
+        Key: 'System.AppUserModel.ID',
+        Value: meta_data.product,
+    });
+
     if (HasProductIcon())
         shortcut.att('Icon', 'ProductIcon');
 


### PR DESCRIPTION
It's required to get the notifications working and documented
by Microsoft (this is valid only here because Crosswalk is not
an UWP app).