### PR TITLE
[DO NOT MERGE] Fix appveyor download

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -568,33 +568,27 @@ function(abi) {
         return false;
     }
 
-    ShellJS.pushd(libsDir);
-
     var abiMatched = false;
-    var list = ShellJS.ls(".");
-    for (var i = 0; i < list.length; i++) {
+    FS.readdirSync(libsDir).forEach(function (entry) {
 
-        var entry = list[i];
-        if (ShellJS.test("-d", entry)) {
-            // This is a dir inside "libs", enable/disable depending
-            // on which ABI we want.
-            if (!abi) {
-                // No ABI passed, enable all of them, this is default
-                // status of the project.
-                ShellJS.chmod("+rx", entry);
-                abiMatched = true;
-            } else if (abi === entry) {
-                // enable
-                ShellJS.chmod("+rx", entry);
-                abiMatched = true;
-            } else {
-                // disable
-                ShellJS.chmod("-rx", entry);
-            }
+        // This is a dir inside "libs", enable/disable depending
+        // on which ABI we want.
+        var libxwalkcore = Path.join(libsDir, entry, "libxwalkcore.so");
+        if (!abi) {
+            // No ABI passed, enable all of them, this is default
+            // status of the project.
+            ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            abiMatched = true;
+        } else if (abi === entry) {
+            // enable
+            ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            abiMatched = true;
+        } else {
+            // disable
+            ShellJS.mv(libxwalkcore, libxwalkcore + ".foo");
         }
-    }
+    });
 
-    ShellJS.popd();
     return abiMatched;
 };
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,7 +22,7 @@ install:
   - 7z x lzma1514.7z
   - cd ..\
   - set PATH=%ANDROID_HOME%\tools;%PATH%;%ANT_HOME%\bin;%WIX_HOME%\bin;C:\lzma\bin;
-  - appveyor DownloadFile http://www.crummy.com/software/BeautifulSoup/bs4/download/4.4/beautifulsoup4-4.4.1.tar.gz
+  - appveyor DownloadFile https://www.crummy.com/software/BeautifulSoup/bs4/download/4.4/beautifulsoup4-4.4.1.tar.gz
   - 7z x beautifulsoup4-4.4.1.tar.gz
   - 7z x dist/beautifulsoup4-4.4.1.tar > nul
   - cd beautifulsoup4-4.4.1


### PR DESCRIPTION
It seems that downloading beautifulSoup requires HTTPs