### PR TITLE
Android: Also skip dummy JNI lib

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -574,18 +574,22 @@ function(abi) {
         // This is a dir inside "libs", enable/disable depending
         // on which ABI we want.
         var libxwalkcore = Path.join(libsDir, entry, "libxwalkcore.so");
+        var libxwalkdummy = Path.join(libsDir, entry, "libxwalkdummy.so");
         if (!abi) {
             // No ABI passed, enable all of them, this is default
             // status of the project.
             ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            ShellJS.mv(libxwalkdummy + ".foo", libxwalkdummy);
             abiMatched = true;
         } else if (abi === entry) {
             // enable
             ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            ShellJS.mv(libxwalkdummy + ".foo", libxwalkdummy);
             abiMatched = true;
         } else {
             // disable
             ShellJS.mv(libxwalkcore, libxwalkcore + ".foo");
+            ShellJS.mv(libxwalkdummy, libxwalkdummy + ".foo");
         }
     });
 


### PR DESCRIPTION
We have a libxwalkcore.so and libxwalkdummy.do for each supported
target architecture. The non-matching dummy lib also needs to be
skipped when building, to not confuse the JNI loader.

BUG=XWALK-6725