### PR TITLE
-pkg: Default to android target platform

### DIFF
--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -439,13 +439,14 @@ if (argv.p || argv.platforms) {
         // Filter empty entries caused by extra whitespace.
         return value;
     });
-} else {
+} else if (ShellJS.test("-f", manifestPath)) {
     json = _readManifest(manifestPath, output);
     if (json.xwalk_target_platforms) {
         extraArgs.platforms = json.xwalk_target_platforms;
-    } else {
-        extraArgs.platforms = [ "android" ];
     }
+}
+if (!extraArgs.platforms) {
+    extraArgs.platforms = [ "android" ];
 }
 
 var buildConfig = null;


### PR DESCRIPTION
Handle test case when building app without manifest, passing
package-id via command-line. When platform is not specified in this
case, default to android.

BUG=XWALK-6698