### PR TITLE
Output: Do not truncate to 80 when non-interactive

### DIFF
--- a/src/TerminalOutput.js
+++ b/src/TerminalOutput.js
@@ -81,8 +81,9 @@ function(message, path) {
         }
 
         var output;
-        if (message.length > 75 && path) {
-            // Overflow, no point in abbreviating
+        if (!process.stdout.isTTY ||
+            (message.length > 75 && path)) {
+            // Non-interactive or overflow, no point in abbreviating
             output = this.prefix + message + " " + path;
         }
         else if (path) {


### PR DESCRIPTION
When not running in an interactive terminal, do not truncate paths
but write full output for complete logfiles.

BUG=XWALK-6826