### PR TITLE
Windows: Use recursive copy when importing crosswalk

### DIFF
--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -102,7 +102,7 @@ function(crosswalkPath) {
     var version = null;
     if (ShellJS.test("-d", crosswalkPath)) {
         ShellJS.mkdir(this.platformPath);
-        ShellJS.cp(Path.join(crosswalkPath, "*"), this.platformPath);
+        ShellJS.cp("-r", Path.join(crosswalkPath, "*"), this.platformPath);
         version = util.Version.createFromFile(Path.join(crosswalkPath, "VERSION"));
     } else {
         var xwalk = new util.CrosswalkZip(crosswalkPath);

--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -236,7 +236,8 @@ function(app_path, xwalk_path, meta_data, callback) {
             AddFileComponent(GetFolderNode('locales', app_root_folder), locales_path, locale);
         });
     } else {
-        // TODO maybe error or warning
+        output.error("Folder 'locales' not found in " + xwalk_path);
+        output.error("Missing i18n support");
     }
 
     // @skip_array contains absolute path of those need to be skipped, items can be


### PR DESCRIPTION
When pulling crosswalk into the build tree use recursive copying, such
that the "locales" folder with its contents is not skipped.

BUG=APPTOOLS-339