### PR TITLE
DO NOT MERGE Android: Use app:// protocol for local start_url

### DIFF
--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -285,7 +285,7 @@ function copy(app, appPath, extraArgs, callback) {
     ShellJS.rm("-rf", Path.join(app.appPath, "*"));
     ShellJS.cp("-r", Path.join(appPath, "*"), app.appPath);
 
-    // Init and load manifest
+    // Initialise and load manifest
     var manifestPath = Path.join(app.appPath, "manifest.json");
     Manifest.addDefaults(output, manifestPath, app.packageId);
     var ret = Manifest.ensureAppProtocol(output, manifestPath, app.packageId);

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -288,6 +288,11 @@ function copy(app, appPath, extraArgs, callback) {
     // Init and load manifest
     var manifestPath = Path.join(app.appPath, "manifest.json");
     Manifest.addDefaults(output, manifestPath, app.packageId);
+    var ret = Manifest.ensureAppProtocol(output, manifestPath, app.packageId);
+    if (!ret) {
+        callback(cat.EXIT_CODE_ERROR);
+        return;
+    }
     app.loadManifest(manifestPath);
 
     // Propagate target platform cause we just nuked the manifest


### PR DESCRIPTION
When packaging, look at the manifest.start_url field, and if it
is a relative url without protocol, rewrite it to use app://
Also make sure the referenced file does actually exist.

Example:
start_url: index.html becomes app://com.example.foo/index.html

BUG=APPTOOLS-160