### PR TITLE
Android: Only package single ABI for crosswalk-lite

### DIFF
--- a/android/lib/AndroidPlatform.js
+++ b/android/lib/AndroidPlatform.js
@@ -574,21 +574,25 @@ function(abi) {
         // This is a dir inside "libs", enable/disable depending
         // on which ABI we want.
         var libxwalkcore = Path.join(libsDir, entry, "libxwalkcore.so");
+        var libxwalkcoreCompressed = Path.join(libsDir, entry, "libxwalkcoreCompressed.so");
         var libxwalkdummy = Path.join(libsDir, entry, "libxwalkdummy.so");
         if (!abi) {
             // No ABI passed, enable all of them, this is default
             // status of the project.
             ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            ShellJS.mv(libxwalkcoreCompressed + ".foo", libxwalkcoreCompressed);
             ShellJS.mv(libxwalkdummy + ".foo", libxwalkdummy);
             abiMatched = true;
         } else if (abi === entry) {
             // enable
             ShellJS.mv(libxwalkcore + ".foo", libxwalkcore);
+            ShellJS.mv(libxwalkcoreCompressed + ".foo", libxwalkcoreCompressed);
             ShellJS.mv(libxwalkdummy + ".foo", libxwalkdummy);
             abiMatched = true;
         } else {
             // disable
             ShellJS.mv(libxwalkcore, libxwalkcore + ".foo");
+            ShellJS.mv(libxwalkcoreCompressed, libxwalkcoreCompressed + ".foo");
             ShellJS.mv(libxwalkdummy, libxwalkdummy + ".foo");
         }
     });


### PR DESCRIPTION
When creating a crosswalk-lite apk, lib/ has all ABIs (armv7 and x86 by
default), so there is no size win. Now also use the ABI skipping logic
for crosswalk lite by considering libxwalkcoreCompressed.so.

BUG=APPTOOLS-341