### PR TITLE
-pkg: Option -s / --skip-check to skip host check before building

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Two executables are provided, `crosswalk-app` implements low level helper comman
     -m --manifest=<package-id>       Fill manifest.json with default values
     -p --platforms=<target-systems>  Specify target platform
     -r --release                     Build release packages
+    -s --skip-check                  Skip host setup check before building
     -t --targets=<target-archs>      Target CPU architectures
     -v --version                     Print tool version
     -w --windows=<windows-conf>      Extra configurations for Windows

--- a/src/crosswalk-pkg
+++ b/src/crosswalk-pkg
@@ -125,6 +125,7 @@ function help() {
         "    -m --manifest=<package-id>       Fill manifest.json with default values\n" +
         "    -p --platforms=<target-systems>  Specify target platform\n" +
         "    -r --release                     Build release packages\n" +
+        "    -s --skip-check                  Skip host setup check before building\n" +
         "    -t --targets=<target-archs>      Target CPU architectures\n" +
         "    -v --version                     Print tool version\n" +
         '    -w --windows=<windows-conf>      Extra configurations for Windows\n' +
@@ -180,8 +181,18 @@ function help() {
 // Check platform
 function check(app, appPath, extraArgs, output, callback) {
 
-    output.highlight("Checking host setup");
-    app.check(extraArgs.platforms, output, callback);
+    // Per default check only on non-interactive termial (logfile ...)
+    if (!extraArgs.hasOwnProperty("skipCheck")) {
+        extraArgs.skipCheck = !process.stdout.isTTY;
+    }
+
+    if (extraArgs.skipCheck) {
+        output.highlight("Skipping host setup check");
+        callback(cat.EXIT_CODE_OK);
+    } else {
+        output.highlight("Checking host setup");
+        app.check(extraArgs.platforms, output, callback);
+    }
 }
 
 // Initialize app tools
@@ -467,6 +478,19 @@ if (argv.r || argv.release) {
 }
 delete argv.r;
 delete argv.release;
+
+// extraArgs.skipCheck is tri-state:
+// unset: default (check if running in interactive terminal)
+// true: skip check
+// false: force check
+if (argv["s"] === "no" ||
+    argv["skip-check"] === "no") {
+    extraArgs.skipCheck = false;
+} else if (argv["s"] || argv["skip-check"]) {
+    extraArgs.skipCheck = true;
+}
+delete argv["s"];
+delete argv["skip-check"];
 
 // Targets
 // By default, build both 32bit targets.

--- a/windows/lib/WinPlatform.js
+++ b/windows/lib/WinPlatform.js
@@ -43,7 +43,7 @@ WinPlatform.getArgs = function() {
             crosswalk: "\t\t\tPath to crosswalk zip"
         },
         build: { // Extra options for command "build"
-            googleApiKeyName: "\t\ŧGoogle API key name in ~/.crosswalk-app-tools-keys.json"
+            googleApiKeyName: "\t\tGoogle API key name in ~/.crosswalk-app-tools-keys.json"
         }
     };
 };


### PR DESCRIPTION
Add command-line option -s / --skip-check. By default, host check is
only enabled when running on an interactive terminal. Using this
parameter, the check can be skipped.

For forcing host check on non-interative systems such as CI, pass
the paramter "-s no" / "--skip-check=no".

BUG=APPTOOLS-303