### PR TITLE
Windows: Do not package locale .pak files twice

### DIFF
--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -192,19 +192,13 @@ function(app_path, xwalk_path, meta_data, callback) {
     AddFileComponent(app_root_folder, xwalk_path, 'VERSION');
 
     // Add all pak files
-    readDir.readSync(xwalk_path).forEach(function (name) {
-        var suffix = name.substring(name.length - ".pak".length);
-        if (suffix && suffix.toLowerCase() === ".pak") {
-            AddFileComponent(app_root_folder, xwalk_path, name);
-        }
+    ShellJS.ls(path.join(xwalk_path, "*.pak")).forEach(function (entry) {
+        AddFileComponent(app_root_folder, xwalk_path, path.basename(entry));
     });
 
     // Add all dll files
-    readDir.readSync(xwalk_path).forEach(function (name) {
-        var suffix = name.substring(name.length - ".dll".length);
-        if (suffix && suffix.toLowerCase() === ".dll") {
-            AddFileComponent(app_root_folder, xwalk_path, name);
-        }
+    ShellJS.ls(path.join(xwalk_path, "*.dll")).forEach(function (entry) {
+        AddFileComponent(app_root_folder, xwalk_path, path.basename(entry));
     });
     
     var subfolder_map = {};

--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -200,7 +200,7 @@ function(app_path, xwalk_path, meta_data, callback) {
     ShellJS.ls(path.join(xwalk_path, "*.dll")).forEach(function (entry) {
         AddFileComponent(app_root_folder, xwalk_path, path.basename(entry));
     });
-    
+
     var subfolder_map = {};
 
     function GetFolderNode(subfolder, root) {


### PR DESCRIPTION
Due to inadvertedly using recursive search for .pak files, they
ended up in the MSI twice: once when actually being added, and
also when the high-dpi assets files (also in .pak format) were
being added.

Fix this by using non-recursive directory listing in both cases.

BUG=APPTOOLS-342