### PR TITLE
Android: Always load app using app:// protocol

### DIFF
--- a/android/lib/JavaActivity.js
+++ b/android/lib/JavaActivity.js
@@ -77,7 +77,7 @@ function(zipEntry, packageId, activityClassName) {
 
     // Always load app from manifest instead of index.html
     templateData = templateData.replace('loadAppFromUrl("file:///android_asset/www/index.html")',
-                                        'loadAppFromManifest("file:///android_asset/www/manifest.json")');
+                                        'loadAppFromManifest("app://' + packageId + '/manifest.json")');
 
     // Do not overwrite activity file because it may contain app-specific code
     // FIXME we should be smarter about this:


### PR DESCRIPTION
We used to use file:// but that has security implications.

BUG=APPTOOLS-345