### PR TITLE
windows : fix breakage after 4d6074 which moves the locales files.

### DIFF
--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -226,7 +226,9 @@ function(app_path, xwalk_path, meta_data, callback) {
         return node;
     }
 
-    var locales_path = path.join(xwalk_path, 'locales');
+    var locales_path = path.join(xwalk_path, 'locales', 'xwalk');
+    if (!fs.existsSync(locales_path))
+	locales_path = path.join(xwalk_path, 'locales');
     if (fs.existsSync(locales_path)) {
         var locales = fs.readdirSync(locales_path);
         locales.forEach(function (locale) {


### PR DESCRIPTION
XWalk locales are now located in locales/xwalk instead of locales/
Special case here by checking the new path and then the old path if
the new path doesn't exist. It will avoid to sync the app-tool release
with the version of Crosswalk after 4d6074.

BUG=APPTOOLS-363