### PR TITLE
[Test] Fix download tests

### DIFF
--- a/test/download-handler.js
+++ b/test/download-handler.js
@@ -35,7 +35,7 @@ exports.tests = {
         ShellJS.rm(tmpPath);
 
         // Download
-        var url = "http://www.linuxfoundation.org";
+        var url = "https://www.linuxfoundation.org";
         var label = "Fetching " + url;
         var indicator = _output.createFiniteProgress(label);
         var stream = handler.createStream();

--- a/test/downloader.js
+++ b/test/downloader.js
@@ -62,37 +62,7 @@ function testFile(url, callback) {
     });
 }
 
-
 exports.tests = {
-
-    httpFile: function(test) {
-
-        test.expect(1);
-
-        testFile("http://www.linuxfoundation.org", function(size) {
-
-            test.equal(size > 0, true);
-            test.done();
-        });
-    },
-
-    httpStream: function(test) {
-
-        test.expect(1);
-
-        var stream = new MemoryStream();
-
-        var buffer = "";
-        stream.on("data", function(chunk) {
-            buffer += chunk.toString();
-        });
-
-        testStream("http://www.linuxfoundation.org", stream, function() {
-
-            test.equal(buffer.length > 0, true);
-            test.done();
-        });
-    },
 
     httpsFile: function(test) {
 


### PR DESCRIPTION
The Linux Foundation URL used to test the download handler needs to be changed to https otherwise it'll return an error.