### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "minimist": "~1.1.0",
     "mktemp": "~0.3.5",
     "mustache": "~0.8.2",
-    "node-uuid": "~1.4.3",
     "parse-color": "~1.0.0",
     "readdir": "~0.0.13",
     "shelljs": "~0.3.0",
+    "uuid": "^3.0.0",
     "xmlbuilder": "~2.6.4",
     "xmldom": "~0.1.19"
   },

--- a/src/util/index.js
+++ b/src/util/index.js
@@ -30,7 +30,7 @@ var util = {
     /** expose some dependencies for hooks */
     AdmZip: require("adm-zip"),
     FormatJson: require("format-json"),
-    NodeUuid: require("node-uuid"),
+    NodeUuid: require("uuid"),
     ParseColor: require("parse-color"),
     XmlBuilder: require("xmlbuilder"),
     XmlDom: require("xmldom"),

--- a/windows/lib/WixSDK.js
+++ b/windows/lib/WixSDK.js
@@ -6,7 +6,7 @@ var child_process = require('child_process');
 
 var builder = require('xmlbuilder');
 var crypto = require('crypto');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var readDir = require('readdir');
 var ShellJS = require("shelljs");
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.